### PR TITLE
Add protocol to copy link action

### DIFF
--- a/src/lib/components/hadithContainer.svelte
+++ b/src/lib/components/hadithContainer.svelte
@@ -136,7 +136,9 @@
             <button
               class="btn bg-primary-500 btn-sm text-black mt-6 pt-3 h-10 rounded-l-full rounded-r-none"
               on:click={clickHandler}
-              use:clipboard={$page.url.host +
+              use:clipboard={$page.url.protocol +
+                "//" + 
+                $page.url.host +
                 "/" +
                 (allHadiths[0].hadiths[i].shortName ?? book) +
                 ":" +


### PR DESCRIPTION
The copy link function didn't include protocol (e.g. http:), so the [copied link](www.hadithhub.com/bukhari:1) wasn't functioning properly in places that use markdown such as GitHub. With protocol, [it works](http://www.hadithhub.com/bukhari:1).